### PR TITLE
Add configurable selftest benchmarking with latency statistics

### DIFF
--- a/benchmark/protocols/pbft/consensus_server.cpp
+++ b/benchmark/protocols/pbft/consensus_server.cpp
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <algorithm>
 
 #include "cxxopts.hpp"
 #include "executor/common/transaction_manager.h"
@@ -77,8 +78,46 @@ std::unique_ptr<ServiceNetwork> CreateServer(const ResDBConfig& config) {
   return std::make_unique<ServiceNetwork>(config, std::move(consensus));
 }
 
+// Simple struct to hold latency statistics.
+struct LatencyStats {
+  double avg_us = 0;
+  double p50_us = 0;
+  double p95_us = 0;
+  double p99_us = 0;
+  double min_us = 0;
+  double max_us = 0;
+};
+
+static double PercentileFromSorted(const std::vector<double>& v, double pct) {
+  if (v.empty()) return 0.0;
+  size_t idx = static_cast<size_t>(pct * (v.size() - 1));
+  return v[idx];
+}
+
+static LatencyStats ComputeLatencyStats(std::vector<double> lat_us) {
+  LatencyStats s;
+  if (lat_us.empty()) return s;
+
+  std::sort(lat_us.begin(), lat_us.end());
+
+  s.min_us = lat_us.front();
+  s.max_us = lat_us.back();
+
+  double sum = 0.0;
+  for (double x : lat_us) sum += x;
+  s.avg_us = sum / lat_us.size();
+
+  s.p50_us = PercentileFromSorted(lat_us, 0.50);
+  s.p95_us = PercentileFromSorted(lat_us, 0.95);
+  s.p99_us = PercentileFromSorted(lat_us, 0.99);
+
+  return s;
+}
+
+// Adding num_requests as a parameter to allow flexibility in testing with different numbers of requests.
+// Keeping its default to 2, to maintain backward compatibility 
 int RunSelfTest(bool use_rdma, const std::string& ip, int base_port,
-                bool use_basic_ring = false) {
+                bool use_basic_ring = false, int num_requests = 2) {
   std::vector<ReplicaInfo> replicas = {
       GenerateReplicaInfo(1, ip, base_port + 1),
       GenerateReplicaInfo(2, ip, base_port + 2),
@@ -128,9 +167,32 @@ int RunSelfTest(bool use_rdma, const std::string& ip, int base_port,
   }
 
   ResDBConfig client_cfg(replicas, ReplicaInfo(), data);
-  client_cfg.SetClientTimeoutMs(5000000);
+  //client_cfg.SetClientTimeoutMs(5000000);
+  client_cfg.SetClientTimeoutMs(5000);
   TransactionConstructor client(client_cfg);
 
+  //---------------------------------------------------------------------
+  // KVRequest set_req;
+  // set_req.set_cmd(KVRequest::SET);
+  // set_req.set_key("light_key");
+  // set_req.set_value("light_value");
+
+  // KVResponse set_resp;
+  // int ret = client.SendRequest(set_req, &set_resp);
+  // bool set_ok = (ret == 0 && set_resp.value() == "ok");
+
+  // KVRequest get_req;
+  // get_req.set_cmd(KVRequest::GET);
+  // get_req.set_key("light_key");
+
+  // KVResponse get_resp;
+  // ret = client.SendRequest(get_req, &get_resp);
+  // bool get_ok = (ret == 0 && get_resp.value() == "light_value");
+
+  // bool ok = set_ok && get_ok;
+  //---------------------------------------------------------------------
+  
+  // Warmup SET so later GETs have a valid key.
   KVRequest set_req;
   set_req.set_cmd(KVRequest::SET);
   set_req.set_key("light_key");
@@ -140,15 +202,48 @@ int RunSelfTest(bool use_rdma, const std::string& ip, int base_port,
   int ret = client.SendRequest(set_req, &set_resp);
   bool set_ok = (ret == 0 && set_resp.value() == "ok");
 
-  KVRequest get_req;
-  get_req.set_cmd(KVRequest::GET);
-  get_req.set_key("light_key");
+  std::vector<double> lat_us;
+  lat_us.reserve(num_requests);
 
-  KVResponse get_resp;
-  ret = client.SendRequest(get_req, &get_resp);
-  bool get_ok = (ret == 0 && get_resp.value() == "light_value");
+  bool get_ok = true;
+  KVResponse last_get_resp;
+
+  auto overall_start = std::chrono::steady_clock::now();
+
+  for (int i = 0; i < num_requests; ++i) {
+    KVRequest get_req;
+    get_req.set_cmd(KVRequest::GET);
+    get_req.set_key("light_key");
+
+    KVResponse get_resp;
+    auto req_start = std::chrono::steady_clock::now();
+    // DEBUG print: Remove Later to avoid cluttering output
+    LOG(ERROR) << "Selftest sending request i=" << i;
+    ret = client.SendRequest(get_req, &get_resp);
+    LOG(ERROR) << "Selftest completed request i=" << i
+           << " ret=" << ret
+           << " value=" << get_resp.value();
+    auto req_end = std::chrono::steady_clock::now();
+
+    double us = std::chrono::duration<double, std::micro>(req_end - req_start).count();
+    lat_us.push_back(us);
+
+    if (!(ret == 0 && get_resp.value() == "light_value")) {
+      get_ok = false;
+    }
+    last_get_resp = get_resp;
+  }
+
+  auto overall_end = std::chrono::steady_clock::now();
+  double total_time_s =
+      std::chrono::duration<double>(overall_end - overall_start).count();
 
   bool ok = set_ok && get_ok;
+  //------------------------------------------------------------------------------
+
+  LatencyStats stats = ComputeLatencyStats(lat_us);
+  double throughput_rps =
+      total_time_s > 0 ? static_cast<double>(num_requests) / total_time_s : 0.0;
 
   for (auto& server : servers) {
     server->Stop();
@@ -159,15 +254,56 @@ int RunSelfTest(bool use_rdma, const std::string& ip, int base_port,
     }
   }
 
+  // if (!ok) {
+  //   LOG(ERROR) << "Self-test failed set_ok=" << set_ok << " get_ok=" << get_ok
+  //              << " set_resp=" << set_resp.value()
+  //              << " get_resp=" << get_resp.value();
+  //   return 1;
+  // }
+  // std::string mode_str = use_rdma ? (use_basic_ring ? "basic_ring" : "rdma") : "tcp";
+  // LOG(ERROR) << "Self-test passed mode=" << mode_str
+  //            << " (SET+GET verified, get_value=" << get_resp.value() << ")";
+  // return 0;
+
+  std::string mode_str =
+      use_rdma ? (use_basic_ring ? "basic_ring" : "rdma") : "tcp";
+
   if (!ok) {
-    LOG(ERROR) << "Self-test failed set_ok=" << set_ok << " get_ok=" << get_ok
+    LOG(ERROR) << "Self-test failed set_ok=" << set_ok
+               << " get_ok=" << get_ok
                << " set_resp=" << set_resp.value()
-               << " get_resp=" << get_resp.value();
+               << " last_get_resp=" << last_get_resp.value();
+    LOG(ERROR) << "RESULT"
+               << " mode=" << mode_str
+               << " num_requests=" << num_requests
+               << " total_time_s=" << total_time_s
+               << " throughput_rps=" << throughput_rps
+               << " avg_us=" << stats.avg_us
+               << " p50_us=" << stats.p50_us
+               << " p95_us=" << stats.p95_us
+               << " p99_us=" << stats.p99_us
+               << " min_us=" << stats.min_us
+               << " max_us=" << stats.max_us
+               << " status=FAIL";
     return 1;
   }
-  std::string mode_str = use_rdma ? (use_basic_ring ? "basic_ring" : "rdma") : "tcp";
+
   LOG(ERROR) << "Self-test passed mode=" << mode_str
-             << " (SET+GET verified, get_value=" << get_resp.value() << ")";
+             << " (GET verified, last_value=" << last_get_resp.value() << ")";
+
+  LOG(ERROR) << "RESULT"
+             << " mode=" << mode_str
+             << " num_requests=" << num_requests
+             << " total_time_s=" << total_time_s
+             << " throughput_rps=" << throughput_rps
+             << " avg_us=" << stats.avg_us
+             << " p50_us=" << stats.p50_us
+             << " p95_us=" << stats.p95_us
+             << " p99_us=" << stats.p99_us
+             << " min_us=" << stats.min_us
+             << " max_us=" << stats.max_us
+             << " status=OK";
+
   return 0;
 }
 
@@ -178,29 +314,49 @@ int main(int argc, char** argv) {
   FLAGS_minloglevel = google::GLOG_ERROR;
 
   // Backward-compatible one-command mode:
-  //   <bin> --selftest [tcp|rdma|basic_ring] [ip] [base_port] [choice]
+  //   <bin> --selftest [tcp|rdma|basic_ring] [ip] [base_port] [num_requests] [choice]
+  //----------------------------------------------------------------------------
+  // if (argc >= 3 && std::string(argv[1]) == "--selftest" &&
+  //     std::string(argv[2]).rfind("-", 0) != 0) {
+  //   const std::string mode = (argc >= 3) ? argv[2] : "tcp";
+  //   const std::string choice = (argc >= 6) ? argv[5] : "shared";
+  //   const bool use_rdma = (mode == "rdma" || mode == "basic_ring");
+  //   const bool use_basic_ring =
+  //       (mode == "basic_ring" || choice == "per_client");
+  //   const std::string ip = (argc >= 4) ? argv[3] : "127.0.0.1";
+  //   const int base_port = (argc >= 5) ? atoi(argv[4]) : 23000;
+  //   return resdb::RunSelfTest(use_rdma, ip, base_port, use_basic_ring);
+  // }
+  //----------------------------------------------------------------------------
+
   if (argc >= 3 && std::string(argv[1]) == "--selftest" &&
       std::string(argv[2]).rfind("-", 0) != 0) {
     const std::string mode = (argc >= 3) ? argv[2] : "tcp";
-    const std::string choice = (argc >= 6) ? argv[5] : "shared";
+    const std::string ip = (argc >= 4) ? argv[3] : "127.0.0.1";
+    const int base_port = (argc >= 5) ? atoi(argv[4]) : 23000;
+    const int num_requests = (argc >= 6) ? atoi(argv[5]) : 2;
+    const std::string choice = (argc >= 7) ? argv[6] : "shared";
+
     const bool use_rdma = (mode == "rdma" || mode == "basic_ring");
     const bool use_basic_ring =
         (mode == "basic_ring" || choice == "per_client");
-    const std::string ip = (argc >= 4) ? argv[3] : "127.0.0.1";
-    const int base_port = (argc >= 5) ? atoi(argv[4]) : 23000;
-    return resdb::RunSelfTest(use_rdma, ip, base_port, use_basic_ring);
+
+    return resdb::RunSelfTest(use_rdma, ip, base_port, use_basic_ring,
+                              num_requests);
   }
 
   cxxopts::Options options(argv[0], "PBFT consensus server");
   options.positional_help("<server.config> <private_key> <cert_file>");
   options.add_options()("selftest", "Run in self-test mode",
                         cxxopts::value<bool>()->default_value("false"))(
-      "mode", "Self-test mode: tcp|rdma",
+      "mode", "Self-test mode: tcp|rdma|basic_ring",
       cxxopts::value<std::string>()->default_value("tcp"))(
       "choice", "RDMA ring mode: shared|per_client (default: shared)",
       cxxopts::value<std::string>()->default_value("shared"))(
       "ip", "Self-test bind IP",
       cxxopts::value<std::string>()->default_value("127.0.0.1"))(
+      "num_requests", "Number of measured GET requests in self-test",
+      cxxopts::value<int>()->default_value("2"))(
       "base_port", "Self-test base port",
       cxxopts::value<int>()->default_value("23000"))(
       "config", "Server config file", cxxopts::value<std::string>())(
@@ -223,6 +379,7 @@ int main(int argc, char** argv) {
     if (parsed["selftest"].as<bool>()) {
       const std::string mode = parsed["mode"].as<std::string>();
       const std::string choice = parsed["choice"].as<std::string>();
+      int num_requests = parsed["num_requests"].as<int>();
       if (mode != "tcp" && mode != "rdma" && mode != "basic_ring") {
         LOG(ERROR) << "Invalid mode: " << mode
                    << ". Expected tcp or rdma.";
@@ -248,7 +405,10 @@ int main(int argc, char** argv) {
       if (base_port == 23000 && parsed.count("private_key")) {
         base_port = atoi(parsed["private_key"].as<std::string>().c_str());
       }
-      return resdb::RunSelfTest(use_rdma, ip, base_port, use_basic_ring);
+      if (num_requests == 2 && parsed.count("cert")) {
+        num_requests = atoi(parsed["cert"].as<std::string>().c_str());
+      }
+      return resdb::RunSelfTest(use_rdma, ip, base_port, use_basic_ring, num_requests);
     }
 
     if (!parsed.count("config") || !parsed.count("private_key") ||

--- a/benchmark/protocols/pbft/results_csv/test1.csv
+++ b/benchmark/protocols/pbft/results_csv/test1.csv
@@ -1,0 +1,199 @@
+timestamp_iso,variant,ip,base_port,trial,exit_code,wall_time_s,client_latency_s,selftest_mode_reported,stdout_tail,stderr_tail,strace_summary,perf_stat
+2026-03-05T18:28:25,tcp,128.110.216.215,2600,1,0,25.02788981699996,0.000134837,tcp,,"E20260305 18:28:03.194255 57597 checkpoint_manager.cpp:530]  add commited state:2
+E20260305 18:28:03.194284 57474 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:03.194255 57420 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:03.194392 57480 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:03.194211 57536 checkpoint_manager.cpp:530]  add commited state:2
+E20260305 18:28:03.194475 57486 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:03.194175 57561 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.194299 57612 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.194608 57447 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:03.194639 57454 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:03.194320 57427 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:03.194722 57459 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:03.194584 57561 checkpoint_manager.cpp:530]  add commited state:2
+E20260305 18:28:03.194661 57501 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:03.194711 57507 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:03.194960 57539 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:3 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.195007 57539 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:03.194766 57432 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:03.195021 57587 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:3 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.195163 57587 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:03.194621 57612 checkpoint_manager.cpp:530]  add commited state:2
+E20260305 18:28:03.195166 57610 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:3 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.195197 57553 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:3 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.195048 57513 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:03.195291 57610 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:03.195350 57553 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:03.218483 57539 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:1 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.218536 57539 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:03.218566 57539 response_manager.cpp:214]  get receive count:0 seq:2
+E20260305 18:28:03.234591 57525 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:4 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.234647 57525 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:03.234691 57525 response_manager.cpp:214]  get receive count:1 seq:2
+E20260305 18:28:03.234763 57525 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:03.234803 57525 response_manager.cpp:227] SendResponseToClient local_id:2 seq:2 proxy_id:1
+E20260305 18:28:03.234833 57525 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:03.234941 57525 response_manager.cpp:259] response sent to client local_id:2 seq:2
+E20260305 18:28:03.234999 57538 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:03.235049 57538 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:04.321079 57411 consensus_server.cpp:169] Self-test passed mode=tcp (SET+GET verified, get_value=light_value)
+E20260305 18:28:05.597982 57412 stats.cpp:474]   req client latency:0.000134837",,
+2026-03-05T18:28:50,rdma,128.110.216.215,2600,1,0,25.080972915999155,6.6975e-06,rdma,"NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 1
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 1
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 2
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 2
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 2
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 2
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 3
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 3
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 3
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+[Server] accepted client 3","E20260305 18:28:28.564949 57685 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:28.565137 57737 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:28.564689 57782 rdma_replica_communicator.cpp:75] [RDMA] send target id=2 ip=128.110.216.215 base_port=2602 rdma_port=2602 payload_bytes=53
+E20260305 18:28:28.565248 57739 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:28.565322 57739 rdma_replica_communicator.cpp:75] [RDMA] send target id=1 ip=128.110.216.215 base_port=2601 rdma_port=2601 payload_bytes=53
+E20260305 18:28:28.565104 57727 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:28.564881 57820 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:4 seq:2 primary:1 is recovery:0
+E20260305 18:28:28.565464 57759 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:4 seq:2 primary:1 is recovery:0
+E20260305 18:28:28.565502 57705 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:28.565351 57787 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:28.565656 57787 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:28.564571 57664 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:28.565173 57695 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:28.565476 57820 checkpoint_manager.cpp:530]  add commited state:2
+E20260305 18:28:28.565506 57759 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:28.565544 57707 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:28.565267 57782 rdma_replica_communicator.cpp:75] [RDMA] send target id=3 ip=128.110.216.215 base_port=2603 rdma_port=2603 payload_bytes=53
+E20260305 18:28:28.565971 57717 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:28.566001 57782 rdma_replica_communicator.cpp:75] [RDMA] send target id=4 ip=128.110.216.215 base_port=2604 rdma_port=2604 payload_bytes=53
+E20260305 18:28:28.565816 57673 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:28.566076 57822 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:28.566126 57822 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:28.565052 57837 checkpoint_manager.cpp:530]  add commited state:2
+E20260305 18:28:28.566078 57673 rdma_replica_communicator.cpp:75] [RDMA] send target id=1 ip=128.110.216.215 base_port=2601 rdma_port=2601 payload_bytes=53
+E20260305 18:28:28.565819 57695 rdma_replica_communicator.cpp:75] [RDMA] send target id=1 ip=128.110.216.215 base_port=2601 rdma_port=2601 payload_bytes=53
+E20260305 18:28:28.565900 57759 response_manager.cpp:214]  get receive count:0 seq:2
+E20260305 18:28:28.566323 57762 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:1 seq:2 primary:1 is recovery:0
+E20260305 18:28:28.566366 57762 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:28.566404 57762 response_manager.cpp:214]  get receive count:1 seq:2
+E20260305 18:28:28.566430 57762 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:28.566468 57762 response_manager.cpp:227] SendResponseToClient local_id:2 seq:2 proxy_id:1
+E20260305 18:28:28.566500 57762 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:28.566618 57762 response_manager.cpp:259] response sent to client local_id:2 seq:2
+E20260305 18:28:28.566011 57717 rdma_replica_communicator.cpp:75] [RDMA] send target id=1 ip=128.110.216.215 base_port=2601 rdma_port=2601 payload_bytes=53
+E20260305 18:28:28.566139 57849 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:28.566336 57761 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:28.566802 57849 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:28.566869 57761 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:29.799614 57659 consensus_server.cpp:169] Self-test passed mode=rdma (SET+GET verified, get_value=light_value)
+E20260305 18:28:30.626072 57660 stats.cpp:474]   req client latency:6.6975e-06",,
+2026-03-05T18:29:15,basic_ring,128.110.216.215,2600,1,0,25.07543221599917,6.754e-06,basic_ring,"NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+>>>>>>>> post recvs
+[BasicServer] accepted client 2
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+>>>>>>>> post recvs
+[BasicServer] accepted client 2
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+>>>>>>>> post recvs
+[BasicServer] accepted client 2
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+>>>>>>>> post recvs
+[BasicServer] accepted client 2
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+>>>>>>>> post recvs
+[BasicServer] accepted client 3
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+>>>>>>>> post recvs
+[BasicServer] accepted client 3
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+>>>>>>>> post recvs
+[BasicServer] accepted client 3
+NO shared receive
+>>>>>>>> post recvs
+connect request had data with it: 56 bytes
+>>>>>>>> post recvs
+[BasicServer] accepted client 3","E20260305 18:28:53.642386 57911 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:53.642225 57961 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:53.641911 57981 rdma_replica_communicator.cpp:75] [RDMA] send target id=4 ip=128.110.216.215 base_port=2604 rdma_port=2604 payload_bytes=53
+E20260305 18:28:53.642266 57877 rdma_replica_communicator.cpp:75] [RDMA] send target id=1 ip=128.110.216.215 base_port=2601 rdma_port=2601 payload_bytes=53
+E20260305 18:28:53.642318 58026 checkpoint_manager.cpp:530]  add commited state:2
+E20260305 18:28:53.642628 58041 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:53.642167 57899 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:53.642735 57899 rdma_replica_communicator.cpp:75] [RDMA] send target id=1 ip=128.110.216.215 base_port=2601 rdma_port=2601 payload_bytes=53
+E20260305 18:28:53.642868 57931 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:53.642912 57961 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:2 seq:2 primary:1 is recovery:0
+E20260305 18:28:53.641597 58024 rdma_replica_communicator.cpp:75] [RDMA] send target id=2 ip=128.110.216.215 base_port=2602 rdma_port=2602 payload_bytes=53
+E20260305 18:28:53.642688 57969 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:1 seq:2 primary:1 is recovery:0
+E20260305 18:28:53.643098 57969 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:53.643127 57986 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:3 seq:2 primary:1 is recovery:0
+E20260305 18:28:53.642462 57921 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:53.643007 57961 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:53.643062 58024 rdma_replica_communicator.cpp:75] [RDMA] send target id=3 ip=128.110.216.215 base_port=2603 rdma_port=2603 payload_bytes=53
+E20260305 18:28:53.642691 58041 checkpoint_manager.cpp:530]  add commited state:2
+E20260305 18:28:53.642961 57941 transaction_manager.cpp:91]  execute batch seq:1
+E20260305 18:28:53.643405 58019 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:3 seq:2 primary:1 is recovery:0
+E20260305 18:28:53.643451 58019 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:53.643471 57943 commitment.cpp:363] send back to proxy:1
+E20260305 18:28:53.643278 57961 response_manager.cpp:214]  get receive count:1 seq:2
+E20260305 18:28:53.643323 58024 rdma_replica_communicator.cpp:75] [RDMA] send target id=4 ip=128.110.216.215 base_port=2604 rdma_port=2604 payload_bytes=53
+E20260305 18:28:53.643142 57969 response_manager.cpp:214]  get receive count:0 seq:2
+E20260305 18:28:53.643179 57986 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:53.643676 58048 consensus_manager_pbft.cpp:208] recv impl type:5 sender id:3 seq:2 primary:1 is recovery:0
+E20260305 18:28:53.643734 58048 message_manager.cpp:188]  seq:2 type:5 has been committed
+E20260305 18:28:53.643232 57921 rdma_replica_communicator.cpp:75] [RDMA] send target id=1 ip=128.110.216.215 base_port=2601 rdma_port=2601 payload_bytes=53
+E20260305 18:28:53.643517 57943 rdma_replica_communicator.cpp:75] [RDMA] send target id=1 ip=128.110.216.215 base_port=2601 rdma_port=2601 payload_bytes=53
+E20260305 18:28:53.643559 57961 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:53.643949 57970 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:3 seq:2 primary:1 is recovery:0
+E20260305 18:28:53.643949 57964 consensus_manager_pbft.cpp:208] recv impl type:7 sender id:4 seq:2 primary:1 is recovery:0
+E20260305 18:28:53.643963 57961 response_manager.cpp:227] SendResponseToClient local_id:2 seq:2 proxy_id:1
+E20260305 18:28:53.643999 57970 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:53.644052 57964 response_manager.cpp:187]  receive request seq:2 type:7 local id:2
+E20260305 18:28:53.644083 57961 lock_free_collector_pool.cpp:71]  update:258 seq:258 cap:256 update seq:2
+E20260305 18:28:53.644289 57961 response_manager.cpp:259] response sent to client local_id:2 seq:2
+E20260305 18:28:54.880153 57863 consensus_server.cpp:169] Self-test passed mode=basic_ring (SET+GET verified, get_value=light_value)
+E20260305 18:28:55.708055 57864 stats.cpp:474]   req client latency:6.754e-06",,

--- a/benchmark/protocols/pbft/run_experiments.py
+++ b/benchmark/protocols/pbft/run_experiments.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""
+ecs251_run_experiments.py
+
+Runs PBFT consensus_server selftest for multiple transport variants and logs metrics into a CSV.
+
+Current variants enabled:
+- tcp
+- rdma
+- basic_ring
+
+fetch_add is intentionally left out for now.
+
+Easy to extend later:
+- Add new variants by adding entries in VARIANTS.
+- Add new collectors by adding a function and wiring it into run_one().
+
+USAGE EXAMPLES:
+
+1) Build once, then run 5 trials of all current variants:
+   python3 run_experiments.py --ip 128.110.216.215 --base-port 26000 --num-requests 1000 --trials 5 --build
+
+2) Only run tcp + rdma:
+   python3 run_experiments.py --ip 128.110.216.215 --base-port 26000 --variants tcp rdma --trials 3 --build
+
+3) Add strace and perf (often requires sudo):
+   sudo python3 ecs251_run_experiments.py --ip 128.110.216.215 --base-port 26000 --num-requests 1000 --trials 3 --build --enable-strace --enable-perf
+
+Notes:
+- Selftest creates 4 replicas in-process and sends 2 requests (SET+GET).
+  This is bring-up/correctness + micro latency printing, not a throughput benchmark.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Optional, Tuple
+
+# -----------------------------
+# Hardcoded fixed paths
+# -----------------------------
+REPO_PATH = "/users/Pranav14/incubator-resilientdb"
+RESULTS_CSV_PATH = "/users/Pranav14/incubator-resilientdb/benchmark/protocols/pbft/results_csv/test1.csv"
+
+# Bazel target + built binary for consensus_server
+DEFAULT_BAZEL_TARGET = "//benchmark/protocols/pbft:consensus_server"
+DEFAULT_BUILT_BIN_REL = "bazel-bin/benchmark/protocols/pbft/consensus_server"
+
+# -----------------------------
+# Variants enabled for now
+# -----------------------------
+VARIANTS: Dict[str, str] = {
+    "tcp":        "--selftest tcp {ip} {base_port} {num_requests}",
+    "rdma":       "--selftest rdma {ip} {base_port} {num_requests}",
+    "basic_ring": "--selftest basic_ring {ip} {base_port} {num_requests}",
+}
+
+# Future placeholder if/when fetch_add gets integrated cleanly:
+# "rdma_fetchadd": "--selftest rdma_fetchadd {ip} {base_port}",
+
+LAT_RE = re.compile(r"req client latency:([0-9.eE+-]+)")
+SELFTEST_PASS_RE = re.compile(r"Self-test passed mode=([a-zA-Z0-9_]+)")
+RESULT_RE = re.compile(
+    r"RESULT "
+    r"mode=(?P<mode>\S+) "
+    r"num_requests=(?P<num_requests>\d+) "
+    r"total_time_s=(?P<total_time_s>[0-9.eE+-]+) "
+    r"throughput_rps=(?P<throughput_rps>[0-9.eE+-]+) "
+    r"avg_us=(?P<avg_us>[0-9.eE+-]+) "
+    r"p50_us=(?P<p50_us>[0-9.eE+-]+) "
+    r"p95_us=(?P<p95_us>[0-9.eE+-]+) "
+    r"p99_us=(?P<p99_us>[0-9.eE+-]+) "
+    r"min_us=(?P<min_us>[0-9.eE+-]+) "
+    r"max_us=(?P<max_us>[0-9.eE+-]+) "
+    r"status=(?P<status>\S+)"
+)
+
+
+@dataclass
+class RunMetrics:
+    timestamp_iso: str
+    variant: str
+    ip: str
+    base_port: int
+    num_requests: int
+    trial: int
+    exit_code: int
+    wall_time_s: float
+
+    # Old parsed fields
+    client_latency_s: Optional[float]
+    selftest_mode_reported: Optional[str]
+
+    # New parsed RESULT fields
+    result_mode: Optional[str]
+    result_num_requests: Optional[int]
+    result_total_time_s: Optional[float]
+    result_throughput_rps: Optional[float]
+    result_avg_us: Optional[float]
+    result_p50_us: Optional[float]
+    result_p95_us: Optional[float]
+    result_p99_us: Optional[float]
+    result_min_us: Optional[float]
+    result_max_us: Optional[float]
+    result_status: Optional[str]
+
+    stdout_tail: str
+    stderr_tail: str
+    strace_summary: str
+    perf_stat: str
+
+
+def ensure_parent_dir(path: str) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+
+def run_cmd(
+    cmd: List[str],
+    cwd: str,
+    timeout_s: Optional[int],
+    env: Optional[dict] = None,
+) -> Tuple[int, str, str, float]:
+    start = time.perf_counter()
+    p = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    try:
+        out, err = p.communicate(timeout=timeout_s)
+        rc = p.returncode
+    except subprocess.TimeoutExpired:
+        p.kill()
+        out, err = p.communicate()
+        rc = 124
+        err = (err or "") + "\n[TIMEOUT] command exceeded timeout\n"
+    wall = time.perf_counter() - start
+    return rc, out or "", err or "", wall
+
+
+def tail(s: str, max_lines: int = 30) -> str:
+    lines = s.splitlines()
+    if len(lines) <= max_lines:
+        return s.strip()
+    return "\n".join(lines[-max_lines:]).strip()
+
+
+def parse_client_latency(output: str) -> Optional[float]:
+    m = LAT_RE.search(output)
+    if not m:
+        return None
+    try:
+        return float(m.group(1))
+    except ValueError:
+        return None
+
+
+def parse_selftest_mode(output: str) -> Optional[str]:
+    m = SELFTEST_PASS_RE.search(output)
+    return m.group(1) if m else None
+
+
+def build_target(repo: str, bazel_target: str) -> None:
+    cmd = ["bazel", "build", bazel_target]
+    rc, out, err, wall = run_cmd(cmd, cwd=repo, timeout_s=None)
+    if rc != 0:
+        print("[ERROR] Bazel build failed.")
+        print(err)
+        sys.exit(rc)
+    print(f"[OK] Build succeeded in {wall:.2f}s")
+
+
+def make_program_path(repo: str, program_path: str) -> str:
+    if os.path.isabs(program_path):
+        return program_path
+    return os.path.join(repo, program_path)
+
+
+def make_variant_args(variant: str, ip: str, base_port: int, num_requests: int) -> List[str]:
+    if variant not in VARIANTS:
+        raise ValueError(f"Unknown variant '{variant}'. Known: {sorted(VARIANTS.keys())}")
+    tmpl = VARIANTS[variant]
+    arg_str = tmpl.format(ip=ip, base_port=base_port, num_requests=num_requests)
+    return shlex.split(arg_str)
+
+
+def collect_strace(
+    repo: str,
+    program: str,
+    prog_args: List[str],
+    timeout_s: Optional[int],
+) -> Tuple[int, str, str, float]:
+    cmd = ["strace", "-f", "-c", program] + prog_args
+    return run_cmd(cmd, cwd=repo, timeout_s=timeout_s)
+
+
+def collect_perf_stat(
+    repo: str,
+    program: str,
+    prog_args: List[str],
+    timeout_s: Optional[int],
+) -> Tuple[int, str, str, float]:
+    cmd = [
+        "perf",
+        "stat",
+        "-e",
+        "cycles,instructions,context-switches,cpu-migrations,page-faults,cache-references,cache-misses",
+        program,
+    ] + prog_args
+    return run_cmd(cmd, cwd=repo, timeout_s=timeout_s)
+
+
+def run_one(
+    repo: str,
+    program: str,
+    variant: str,
+    ip: str,
+    base_port: int,
+    num_requests: int,
+    trial: int,
+    timeout_s: Optional[int],
+    enable_strace: bool,
+    enable_perf: bool,
+) -> RunMetrics:
+    prog_args = make_variant_args(variant, ip, base_port, num_requests)
+
+    rc, out, err, wall = run_cmd([program] + prog_args, cwd=repo, timeout_s=timeout_s)
+
+    combined = out + "\n" + err
+    lat = parse_client_latency(combined)
+    mode_reported = parse_selftest_mode(combined)
+    result_metrics = parse_result_metrics(combined)
+
+    strace_summary = ""
+    perf_stat = ""
+
+    if enable_strace:
+        _, out_s, err_s, _ = collect_strace(repo, program, prog_args, timeout_s)
+        strace_summary = tail(out_s + "\n" + err_s, max_lines=200)
+
+    if enable_perf:
+        _, out_p, err_p, _ = collect_perf_stat(repo, program, prog_args, timeout_s)
+        perf_stat = tail(out_p + "\n" + err_p, max_lines=200)
+
+    return RunMetrics(
+        timestamp_iso=dt.datetime.now().isoformat(timespec="seconds"),
+        variant=variant,
+        ip=ip,
+        base_port=base_port,
+        trial=trial,
+        exit_code=rc,
+        wall_time_s=wall,
+        client_latency_s=lat,
+        selftest_mode_reported=mode_reported,
+        result_mode=result_metrics["result_mode"],
+        result_num_requests=result_metrics["result_num_requests"],
+        result_total_time_s=result_metrics["result_total_time_s"],
+        result_throughput_rps=result_metrics["result_throughput_rps"],
+        result_avg_us=result_metrics["result_avg_us"],
+        result_p50_us=result_metrics["result_p50_us"],
+        result_p95_us=result_metrics["result_p95_us"],
+        result_p99_us=result_metrics["result_p99_us"],
+        result_min_us=result_metrics["result_min_us"],
+        result_max_us=result_metrics["result_max_us"],
+        result_status=result_metrics["result_status"],
+        stdout_tail=tail(out, max_lines=40),
+        stderr_tail=tail(err, max_lines=40),
+        strace_summary=strace_summary,
+        perf_stat=perf_stat,
+        num_requests=num_requests,
+    )
+
+
+def append_csv(path: str, rows: List[RunMetrics]) -> None:
+    ensure_parent_dir(path)
+    file_exists = os.path.exists(path)
+
+    dict_rows = [asdict(r) for r in rows]
+    fieldnames = list(dict_rows[0].keys()) if dict_rows else []
+
+    with open(path, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        if not file_exists:
+            w.writeheader()
+        for r in dict_rows:
+            w.writerow(r)
+
+def parse_result_metrics(output: str) -> Dict[str, Optional[object]]:
+    m = RESULT_RE.search(output)
+    if not m:
+        return {
+            "result_mode": None,
+            "result_num_requests": None,
+            "result_total_time_s": None,
+            "result_throughput_rps": None,
+            "result_avg_us": None,
+            "result_p50_us": None,
+            "result_p95_us": None,
+            "result_p99_us": None,
+            "result_min_us": None,
+            "result_max_us": None,
+            "result_status": None,
+        }
+
+    return {
+        "result_mode": m.group("mode"),
+        "result_num_requests": int(m.group("num_requests")),
+        "result_total_time_s": float(m.group("total_time_s")),
+        "result_throughput_rps": float(m.group("throughput_rps")),
+        "result_avg_us": float(m.group("avg_us")),
+        "result_p50_us": float(m.group("p50_us")),
+        "result_p95_us": float(m.group("p95_us")),
+        "result_p99_us": float(m.group("p99_us")),
+        "result_min_us": float(m.group("min_us")),
+        "result_max_us": float(m.group("max_us")),
+        "result_status": m.group("status"),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run PBFT selftest experiments (TCP/RDMA/basic_ring) and log metrics to CSV.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        epilog="Tip: Bind to an IP that exists on this host (use `hostname -I`). perf/strace may require sudo.",
+    )
+
+    parser.add_argument(
+        "--bazel-target",
+        default=DEFAULT_BAZEL_TARGET,
+        help="Bazel target to build (optional)",
+    )
+    parser.add_argument(
+        "--program",
+        default=DEFAULT_BUILT_BIN_REL,
+        help="Program path to run (absolute or repo-relative). Default is bazel-bin output for consensus_server.",
+    )
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="Run `bazel build <target>` once before experiments.",
+    )
+
+    parser.add_argument(
+        "--ip",
+        required=True,
+        help="Bind IP used by selftest replicas (must exist on this machine)",
+    )
+    parser.add_argument(
+        "--base-port",
+        type=int,
+        default=26000,
+        help="Base port for selftest (replicas use base+1..base+4)",
+    )
+    parser.add_argument(
+        "--variants",
+        nargs="+",
+        default=["tcp", "rdma", "basic_ring"],
+        help=f"Variants to run. Known: {sorted(VARIANTS.keys())}",
+    )
+    parser.add_argument(
+        "--trials",
+        type=int,
+        default=3,
+        help="How many trials per variant",
+    )
+    parser.add_argument(
+        "--timeout-s",
+        type=int,
+        default=120,
+        help="Timeout per run (seconds)",
+    )
+
+    parser.add_argument(
+        "--enable-strace",
+        action="store_true",
+        help="Collect `strace -f -c` summary for each run (slow)",
+    )
+    parser.add_argument(
+        "--enable-perf",
+        action="store_true",
+        help="Collect `perf stat` counters for each run (may require sudo)",
+    )
+
+    parser.add_argument(
+        "--num-requests",
+        type=int,
+        default=1000,
+        help="Number of measured GET requests to run in selftest",
+    )
+
+    args = parser.parse_args()
+
+    repo = os.path.abspath(REPO_PATH)
+    if not os.path.isdir(repo):
+        print(f"[ERROR] Hardcoded REPO_PATH not found: {repo}")
+        print("Edit REPO_PATH at the top of this script to match your machine.")
+        return 2
+
+    if args.build:
+        build_target(repo, args.bazel_target)
+
+    program = make_program_path(repo, args.program)
+    if not os.path.exists(program):
+        print(f"[ERROR] Program not found: {program}")
+        print("Did you run with --build? Or is --program pointing to the right bazel-bin path?")
+        return 2
+
+    all_rows: List[RunMetrics] = []
+    print(f"[INFO] Repo: {repo}")
+    print(f"[INFO] Writing results to: {RESULTS_CSV_PATH}")
+
+    for variant in args.variants:
+        print(f"\n[INFO] Variant: {variant}")
+        for t in range(1, args.trials + 1):
+            print(f"[INFO]  Trial {t}/{args.trials} ...")
+            row = run_one(
+                repo=repo,
+                program=program,
+                variant=variant,
+                ip=args.ip,
+                base_port=args.base_port,
+                num_requests=args.num_requests,
+                trial=t,
+                timeout_s=args.timeout_s,
+                enable_strace=args.enable_strace,
+                enable_perf=args.enable_perf,
+            )
+            all_rows.append(row)
+            print(
+                f"[INFO]    exit={row.exit_code} "
+                f"wall={row.wall_time_s:.4f}s "
+                f"mode={row.result_mode or row.selftest_mode_reported or 'NA'} "
+                f"reqs={row.result_num_requests if row.result_num_requests is not None else args.num_requests} "
+                f"avg_us={row.result_avg_us if row.result_avg_us is not None else 'NA'} "
+                f"p95_us={row.result_p95_us if row.result_p95_us is not None else 'NA'} "
+                f"throughput_rps={row.result_throughput_rps if row.result_throughput_rps is not None else 'NA'} "
+                f"status={row.result_status or 'NA'}"
+            )
+
+    if all_rows:
+        append_csv(RESULTS_CSV_PATH, all_rows)
+        print(f"\n[OK] Appended {len(all_rows)} rows to {RESULTS_CSV_PATH}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Add configurable selftest benchmarking with latency statistics and RESULT output

	- Add num_requests parameter to PBFT selftest to run configurable number of operations instead of fixed 2 requests
	- Implement per-request latency measurement using std::chrono
	- Compute latency statistics: avg, p50, p95, p99, min, max
	- Measure total runtime and compute throughput (requests/sec)
	- Print structured RESULT line with all metrics for automated parsing
	- Extend CLI to support --num_requests and positional selftest argument
	- Update experiment script to pass num_requests and parse RESULT metrics
	- Store latency percentiles and throughput in experiment CSV for analysis and graph generation